### PR TITLE
Fix event recording in alloc with --release

### DIFF
--- a/src/machine.rs
+++ b/src/machine.rs
@@ -171,7 +171,8 @@ impl Machine {
         }
 
         self.memory_used = self.memory_used.saturating_add(requested.size);
-        debug_assert!(self.regions.insert(requested.ptr, requested).is_none());
+        let existing = self.regions.insert(requested.ptr, requested); 
+        debug_assert!(existing.is_none());
         Ok(())
     }
 

--- a/tests/diagnostics_tests.rs
+++ b/tests/diagnostics_tests.rs
@@ -4,7 +4,12 @@ static ALLOCATOR: checkers::Allocator = checkers::Allocator::system();
 #[test]
 fn test_event_inspection() {
     let snapshot = checkers::with(|| {
-        let _ = vec![1, 2, 3, 4];
+        let mut x = vec![1, 2, 3, 4];
+        // Prevent optimization in `--release`
+        unsafe {
+            let base = x.as_mut_ptr();
+            std::ptr::write_volatile(base, 5);
+        }
     });
 
     assert_eq!(2, snapshot.events.len());

--- a/tests/leaky_tests.rs
+++ b/tests/leaky_tests.rs
@@ -4,7 +4,11 @@ static CHECKED: checkers::Allocator = checkers::Allocator::system();
 #[checkers::test]
 #[should_panic]
 fn test_leak_box() {
-    let _ = Box::into_raw(Box::new(0u128));
+    let x = Box::into_raw(Box::new(0u128));
+    // Prevent optimization in `--release`
+    unsafe {
+        std::ptr::write_volatile(x, 1u128);
+    }
 }
 
 #[checkers::test]
@@ -22,5 +26,9 @@ fn verify_test_custom_verify(state: &mut checkers::State) {
 
 #[checkers::test(verify = "verify_test_custom_verify")]
 fn test_custom_verify() {
-    let _ = Box::into_raw(vec![1, 2, 3, 4, 5].into_boxed_slice());
+    let x = Box::into_raw(vec![1, 2, 3, 4, 5].into_boxed_slice());
+    // Prevent optimization in `--release`
+    unsafe {
+        std::ptr::write_volatile(x as _, 6);
+    }
 }


### PR DESCRIPTION
`debug_assert` doesn't execute the expression at all in release mode, so hoist the event recording.

Drive-by commits:

* Update tests to work with current Vec reallocation strategy
* Fight the fact that LLVM is too smart and starts optimizing allocations away